### PR TITLE
Fix geolocation cubit permission handling

### DIFF
--- a/lib/bloc/geolocation_cubit/geolocation_cubit.dart
+++ b/lib/bloc/geolocation_cubit/geolocation_cubit.dart
@@ -9,10 +9,10 @@ class GeolocationCubit extends Cubit<GeolocationState> {
     bool trackContinuously = false,
     this.locationSettings = const LocationSettings(accuracy: LocationAccuracy.best),
   }) : super(LocationLoadingState()) {
-    _initialize().then((permission) {
-      if (permission) {
-        getUserLocation();
-      }
+    _initialize().then((permissionGranted) {
+      if (!permissionGranted) return;
+
+      getUserLocation();
 
       if (trackContinuously) {
         trackUserLocation();


### PR DESCRIPTION
## Summary
- ensure GeolocationCubit doesn't start tracking location when permission isn't granted

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840391f5d6c8326a3f47c3bdab2d914